### PR TITLE
Remove imagePullSecrets

### DIFF
--- a/kubernetes/flask/deployment.yaml
+++ b/kubernetes/flask/deployment.yaml
@@ -28,5 +28,3 @@ spec:
             name: shadowmail-config
         - secretRef:
             name: flask-secrets
-      imagePullSecrets:
-      - name: docker-config

--- a/kubernetes/postfix/deployment.yaml
+++ b/kubernetes/postfix/deployment.yaml
@@ -36,8 +36,6 @@ spec:
             name: postfix-config
         - secretRef:
             name: postfix-secrets
-      imagePullSecrets:
-      - name: docker-config
       volumes:
       - name: ssl
         secret:


### PR DESCRIPTION
Image pull secrets are now set on the default service account
using a cronjob.  They no longer need to be sepcified in
deployments.