### PR TITLE
Add node selector to postfix deployment

### DIFF
--- a/kubernetes/postfix/deployment.yaml
+++ b/kubernetes/postfix/deployment.yaml
@@ -43,3 +43,5 @@ spec:
       - name: postfix-spool
         persistentVolumeClaim:
           claimName: postfix-spool
+      nodeSelector:
+        ptr: shadowmail.co.uk


### PR DESCRIPTION
The postfix deployment requires a PTR record to avoid spam
filters.  This requires it to be deployed to a specific node
which satisfies this contraint.