### PR TITLE
Add metrics to flask app

### DIFF
--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -21,10 +21,12 @@ ENV FLASK_DEBUG=1
 
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY app $APP_HOME
 
+COPY app/requirements.txt /app/requirements.txt
 RUN pip install -r $APP_HOME/requirements.txt
 RUN pip install gunicorn
+
+COPY app $APP_HOME
 
 COPY --from=static /static/out /app/static
 

--- a/flask/app/main.py
+++ b/flask/app/main.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
 import os
+
 from flask_api import FlaskAPI
 from flask_sqlalchemy import SQLAlchemy
 from flask_limiter import Limiter
 from flask_mail import Mail
+from prometheus_flask_exporter import PrometheusMetrics
 
 app = FlaskAPI(__name__)
 
@@ -16,6 +18,8 @@ email_limiter = Limiter(app)
 ip_limiter = Limiter(app)
 
 mail = Mail(app)
+
+metrics = PrometheusMetrics(app)
 
 from models.virtual_alias import *
 from views.api import *

--- a/flask/app/requirements.txt
+++ b/flask/app/requirements.txt
@@ -18,6 +18,8 @@ limits==1.2.1
 MarkupSafe==0.23
 mccabe==0.6.1
 packaging==16.8
+prometheus-client==0.7.1
+prometheus-flask-exporter==0.9.1
 psycopg2==2.8.3
 py==1.4.33
 pylint==2.2.2

--- a/kubernetes/flask/deployment.yaml
+++ b/kubernetes/flask/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         app: shadowmail
         component: flask
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '80'
     spec:
       containers:
       - name: flask

--- a/kubernetes/flask/ingress.yaml
+++ b/kubernetes/flask/ingress.yaml
@@ -10,6 +10,10 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+          location /metrics {
+            return 404;
+          }
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Prometheus can pull metrics from a /metrics endpoint
to give further detail about the usage of a pod.  This
endpoint should only be used internally so an exception
is added to the ingress to block outside access to this
endpoint.