### PR TITLE
Fix mail server uri in backend

### DIFF
--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -54,12 +54,12 @@ class Development(Config):
     CREATE_EMAIL_RATE_LIMIT = '3000/30minutes'
     REQUEST_DELETE_RATE_LIMIT = '1000/30minutes'
 
-class Docker(Config):
+class Production(Config):
     DEVELOPMENT = False
     DEBUG = False
     TESTING = False
     SECRET_KEY = os.environ['SECRET_KEY']
     SQLALCHEMY_DATABASE_URI = get_database_uri()
-    MAIL_SERVER = 'postfix'
+    MAIL_SERVER = os.environ.get('MAIL_SERVER_URI')
     MAIL_PORT = 25
     MAIL_USE_TLS = True

--- a/kubernetes/flask.yaml
+++ b/kubernetes/flask.yaml
@@ -40,8 +40,9 @@ metadata:
   namespace: shadowmail
 data:
   DB_DOMAIN: "${DB_DOMAIN}"
+  MAIL_SERVER_URI: "shadowmail-postfix-service.shadowmail.svc.cluster.local"
   FLASK_APP: "/app/main.py"
-  APP_SETTINGS: "Docker" 
+  APP_SETTINGS: Production
   DB_PROTOCOL: postgres
 ---
 apiVersion: v1


### PR DESCRIPTION
The backend was configured to use the backend uri name from when this
was hosted with docker-compose.  This has been updated to use the uri
for kubernetes.