### PR TITLE
Redesign postfix docker image

### DIFF
--- a/postfix/Dockerfile
+++ b/postfix/Dockerfile
@@ -1,6 +1,4 @@
-# Taken from https://github.com/tozd/docker-postfix/
-# Needs to be compiled with postgresql support
-FROM tozd/runit:ubuntu-trusty
+FROM ubuntu
 
 EXPOSE 25/tcp 465/tcp 587/tcp
 
@@ -8,22 +6,16 @@ VOLUME /var/log/postfix
 VOLUME /var/spool/postfix
 VOLUME /ssl
 
-ENV MAILNAME mail.example.com
-ENV MY_NETWORKS 172.17.0.0/16 127.0.0.0/8
-ENV MY_DESTINATION localhost.localdomain, localhost
-ENV ROOT_ALIAS admin@example.com
+# Ignore apt-get prompts
+ENV  DEBIAN_FRONTEND=noninteractive
 
-# We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.
-RUN apt-get update -q -q && \
- echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections && \
- echo postfix postfix/mynetworks string "127.0.0.0/8" | debconf-set-selections && \
- echo postfix postfix/mailname string temporary.example.com | debconf-set-selections && \
- apt-get --yes --force-yes install postfix-pgsql && \
- postconf -e mydestination="localhost.localdomain, localhost" && \
- postconf -e smtpd_banner='$myhostname ESMTP $mail_name' && \
- postconf -# myhostname && \
- postconf -e inet_protocols=ipv4 && \
- apt-get --yes --force-yes --no-install-recommends install rsyslog && \
- sed -i 's/\/var\/log\/mail/\/var\/log\/postfix\/mail/' /etc/rsyslog.d/50-default.conf
+RUN apt-get update
+RUN apt-get install --yes postfix postfix-pgsql
+RUN echo "mail.shadowmail.co.uk" > /etc/mailname
+RUN apt-get install -y syslog-ng
 
 COPY ./etc /etc
+
+COPY ./entrypoint.sh /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/postfix/entrypoint.sh
+++ b/postfix/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "user = $DB_USERNAME" >> /etc/postfix/pgsql-aliases.cf
+echo "password = $DB_PASSWORD" >> /etc/postfix/pgsql-aliases.cf
+echo "hosts = $DB_HOSTS" >> /etc/postfix/pgsql-aliases.cf
+
+echo "mail.$MAILNAME	OK" >> /etc/postfix/virtual_mailbox_domains
+postmap /etc/postfix/virtual_mailbox_domains
+
+useradd -r -d /var/spool/filter filter
+mkdir /var/spool/filter
+chown filter:filter /var/spool/filter
+chmod 750 /var/spool/filter
+
+service syslog-ng start
+postfix start-fg

--- a/postfix/etc/postfix/main.cf
+++ b/postfix/etc/postfix/main.cf
@@ -1,5 +1,6 @@
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 
+maillog_file = /dev/stdout
 
 # Debian specific:  Specifying a file name will cause the first
 # line of that file to be used as the name.  The Debian default
@@ -39,7 +40,7 @@ append_dot_mydomain = no
 
 readme_directory = no
 
-myhostname = mailout.shadowmail.co.uk
+myhostname = mail.shadowmail.co.uk
 mydestination = shadowmail.co.uk, mail.shadowmail.co.uk, localhost
 relayhost = 
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 flask


### PR DESCRIPTION
The existing docker image used broke in production and figuring
out why was not going well.  The image was also from and "untrusted"
source on docker hub and was designed to auto-restart - something
which should be left to Kubernetes.

This new image is based on the ubuntu image which is much safer, is
custom built so better understood and dies on a postfix crash allowing
kubernetes to handle the failure.