### PR TITLE
Add postlog service to master.cf

### DIFF
--- a/postfix/etc/postfix/master.cf
+++ b/postfix/etc/postfix/master.cf
@@ -63,6 +63,7 @@ virtual   unix  -       n       n       -       -       virtual
 lmtp      unix  -       -       y       -       -       lmtp
 anvil     unix  -       -       y       -       1       anvil
 scache    unix  -       -       y       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd
 #
 # ====================================================================
 # Interfaces to non-Postfix software. Be sure to examine the manual


### PR DESCRIPTION
The ubuntu image has bumped postfix from 3.3.0 to 3.4.10.
The new version requires the addition of this service.