### PR TITLE
Remove built.js script tag from html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,6 +12,5 @@
   <link rel="shortcut icon" href="/favicon.png"></head>
   <body>
     <div id="app"></div>
-    <!-- built files will be auto injected -->
-  <script type="text/javascript" src="/build.js"></script></body>
+  </body>
 </html>


### PR DESCRIPTION
This tag is automatically injected.  By including it ourselves we
are initialising the app twice causing all requests to be sent
twice