### PR TITLE
Fix flask tests failing on first run

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,6 @@ jobs:
         cd flask/
         make install
         pip install pylint pytest
-        flask initdb
         make test
 
   test_frontend:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
         cd flask/
         make install
         pip install pylint pytest
-        flask initdb
         make test
 
   test_frontend:

--- a/flask/views/test_api.py
+++ b/flask/views/test_api.py
@@ -18,12 +18,14 @@ def _set_up_client(request):
     app_context.push()
     def tear_down_client():
         db.drop_all()
-        db.configure_mappers()
-        db.create_all()
         db.session.commit()
 
         app_context.pop()
     request.addfinalizer(tear_down_client)
+
+    db.configure_mappers()
+    db.create_all()
+    db.session.commit()
 
 @pytest.fixture()
 def _clear_db():


### PR DESCRIPTION
The database for the flask tests is created on test teardown so
any tests which require database access fail when ran for the first
time.

This is problematic for CI pipelines